### PR TITLE
[18.0] [FIX] mass_mailing_custom_unsubscribe: Allow redirect to mailing list manager on unsubscribe

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*

--- a/mass_mailing_custom_unsubscribe/README.rst
+++ b/mass_mailing_custom_unsubscribe/README.rst
@@ -30,12 +30,22 @@ Mass mailing unsubscription metadata
 
 This addon extends the Odoo subscription engine to provide proof on why
 you are sending mass mailings to a given contact, as required by the
-GDPR in Europe.
+GDPR in Europe. Also, when you unsubscribe from a specific list, it
+allows you to be redirected to the subscription lists form where the
+reasons for unsubscribing are visible.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Configuration
+=============
+
+In order to redirect direct unsubscriptions to the Mailing Subscriptions
+form, you need to create the system parameter
+``mass_mailing.mailing_lists_unsubscribe_manager_redirect`` with value
+``1``. Otherwise, the redirect won't happen.
 
 Usage
 =====
@@ -47,7 +57,10 @@ Once configured:
    *Footers*, so people have an *Unsubscribe* link.
 3. Send it.
 4. If somebody gets unsubscribed, you will see logs about that under
-   *Email Marketing > Unsubscriptions*.
+   *Email Marketing > Reporting > Opt-Out report (List view) > Choose
+   one*
+5. Choose a Newsletter with Opt Out, open this record and see Metadata
+   field
 
 Bug Tracker
 ===========
@@ -81,6 +94,8 @@ Contributors
   - Carlos Roca
   - Pilar Vargas
   - Carlos Lopez
+
+- Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 -----------

--- a/mass_mailing_custom_unsubscribe/controllers/main.py
+++ b/mass_mailing_custom_unsubscribe/controllers/main.py
@@ -2,13 +2,36 @@
 # Copyright 2016 Tecnativa - Jairo Llopis
 # Copyright 2020 Tecnativa - Pedro M. Baeza
 # Copyright 2024 Tecnativa - David Vidal
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.http import request, route
+from odoo.tools.misc import str2bool
 
 from odoo.addons.mass_mailing.controllers.main import MassMailController
 
 
 class CustomUnsubscribe(MassMailController):
+    @route()
+    def mailing_confirm_unsubscribe(
+        self, mailing_id, document_id=None, email=None, hash_token=None
+    ):
+        """Redirect to the unsubscribe page if the redirect option is enabled."""
+        if str2bool(
+            request.env["ir.config_parameter"]
+            .sudo()
+            .get_param("mass_mailing.mailing_lists_unsubscribe_redirect", "0")
+        ):
+            # Redirect to mailing_unsubscribe() route
+            return request.redirect(
+                request.httprequest.path.replace(
+                    "/confirm_unsubscribe", "/unsubscribe"
+                ),
+                code=302,
+            )
+        return super().mailing_confirm_unsubscribe(
+            mailing_id, document_id=document_id, email=email, hash_token=hash_token
+        )
+
     def _mailing_unsubscribe_from_list(self, mailing, document_id, email, hash_token):
         self._add_metadata()
         return super()._mailing_unsubscribe_from_list(

--- a/mass_mailing_custom_unsubscribe/readme/CONFIGURE.md
+++ b/mass_mailing_custom_unsubscribe/readme/CONFIGURE.md
@@ -1,0 +1,4 @@
+
+In order to redirect direct unsubscriptions to the Mailing Subscriptions form,
+you need to create the system parameter `mass_mailing.mailing_lists_unsubscribe_manager_redirect` with value `1`.
+Otherwise, the redirect won't happen.

--- a/mass_mailing_custom_unsubscribe/readme/CONTRIBUTORS.md
+++ b/mass_mailing_custom_unsubscribe/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
   - Carlos Roca
   - Pilar Vargas
   - Carlos Lopez
+
+- Eduardo de Miguel ([Moduon](https://www.moduon.team/))

--- a/mass_mailing_custom_unsubscribe/readme/DESCRIPTION.md
+++ b/mass_mailing_custom_unsubscribe/readme/DESCRIPTION.md
@@ -1,2 +1,4 @@
 This addon extends the Odoo subscription engine to provide proof on why you are sending
 mass mailings to a given contact, as required by the GDPR in Europe.
+Also, when you unsubscribe from a specific list, it allows you to be redirected to the
+subscription lists form where the reasons for unsubscribing are visible.

--- a/mass_mailing_custom_unsubscribe/readme/USAGE.md
+++ b/mass_mailing_custom_unsubscribe/readme/USAGE.md
@@ -5,4 +5,5 @@ Once configured:
     *Footers*, so people have an *Unsubscribe* link.
 3.  Send it.
 4.  If somebody gets unsubscribed, you will see logs about that under
-    *Email Marketing \> Unsubscriptions*.
+    *Email Marketing > Reporting > Opt-Out report (List view) > Choose one*
+5.  Choose a Newsletter with Opt Out, open this record and see Metadata field

--- a/mass_mailing_custom_unsubscribe/static/description/index.html
+++ b/mass_mailing_custom_unsubscribe/static/description/index.html
@@ -372,22 +372,32 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/mass-mailing/tree/18.0/mass_mailing_custom_unsubscribe"><img alt="OCA/mass-mailing" src="https://img.shields.io/badge/github-OCA%2Fmass--mailing-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/mass-mailing-18-0/mass-mailing-18-0-mass_mailing_custom_unsubscribe"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/mass-mailing&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This addon extends the Odoo subscription engine to provide proof on why
 you are sending mass mailings to a given contact, as required by the
-GDPR in Europe.</p>
+GDPR in Europe. Also, when you unsubscribe from a specific list, it
+allows you to be redirected to the subscription lists form where the
+reasons for unsubscribing are visible.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>In order to redirect direct unsubscriptions to the Mailing Subscriptions
+form, you need to create the system parameter
+<tt class="docutils literal">mass_mailing.mailing_lists_unsubscribe_manager_redirect</tt> with value
+<tt class="docutils literal">1</tt>. Otherwise, the redirect won’t happen.</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>Once configured:</p>
 <ol class="arabic simple">
 <li>Go to <em>Email Marketing &gt; Mailings &gt; Create</em>.</li>
@@ -395,11 +405,14 @@ GDPR in Europe.</p>
 <em>Footers</em>, so people have an <em>Unsubscribe</em> link.</li>
 <li>Send it.</li>
 <li>If somebody gets unsubscribed, you will see logs about that under
-<em>Email Marketing &gt; Unsubscriptions</em>.</li>
+<em>Email Marketing &gt; Reporting &gt; Opt-Out report (List view) &gt; Choose
+one</em></li>
+<li>Choose a Newsletter with Opt Out, open this record and see Metadata
+field</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/mass-mailing/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -407,15 +420,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Rafael Blasco</li>
@@ -429,10 +442,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Carlos Lopez</li>
 </ul>
 </li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/mass_mailing_custom_unsubscribe/tests/test_ui.py
+++ b/mass_mailing_custom_unsubscribe/tests/test_ui.py
@@ -94,3 +94,25 @@ class UICase(HttpCase):
         blacklist = self.env["mail.blacklist"].search([("email", "=", partner.email)])
         self.assertEqual(blacklist.opt_out_reason_id.name, "Other")
         self.assertTrue("REMOTE_ADDR" in "".join(blacklist.message_ids.mapped("body")))
+
+    def test_mailing_unsubscribe_redirect(self):
+        """Test that /confirm_unsubscribe redirects to /unsubscribe."""
+        # Create parameter to enable redirect
+        self.env["ir.config_parameter"].sudo().set_param(
+            "mass_mailing.mailing_lists_unsubscribe_redirect", "1"
+        )
+        # Change mailing to be sent to partner
+        partner_id = self.env["res.partner"].name_create(
+            f"Demo Partner <{self.email}>"
+        )[0]
+        self.mailing.mailing_model_id = self.env.ref("base.model_res_partner")
+        self.mailing.mailing_domain = repr(
+            [("is_blacklisted", "=", False), ("id", "=", partner_id)]
+        )
+        with self.mail_postprocess_patch:
+            self.mailing.action_send_mail()
+            result = self.url_open(self.url, allow_redirects=False)
+            self.assertTrue(result.ok)
+            self.assertTrue(result.is_redirect)
+            self.assertFalse(result.is_permanent_redirect)
+            self.assertIn("/unsubscribe", result.next.url)


### PR DESCRIPTION
When unsubscribing from a list, you cannot select a reason until you go to the mailing list manager. Now, you can choose with a system parameter to redirect directly to the mailing list manager and give the user in the first place an option to select a reason to opt out.

https://www.loom.com/share/7801fec1afb24e1bb51c74b0c1fdbe1d

MT-12505 @moduon @yajo @EmilioPascual @chienandalu @rafaelbn please review if you want 😄 