### PR TITLE
[18.0][IMP] mass_mailing_partner: don't edit first/last names if synced

### DIFF
--- a/mass_mailing_partner/views/mailing_contact_view.xml
+++ b/mass_mailing_partner/views/mailing_contact_view.xml
@@ -46,6 +46,23 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="mailing_contact_view_form_split_name">
+        <field name="name">Mailing partner makes first and last names readonly</field>
+        <field name="model">mailing.contact</field>
+        <field
+            name="inherit_id"
+            ref="mass_mailing.mailing_contact_view_form_split_name"
+        />
+        <field name="arch" type="xml">
+            <field name="first_name" position="attributes">
+                <attribute name="readonly">partner_id</attribute>
+            </field>
+            <field name="last_name" position="attributes">
+                <attribute name="readonly">partner_id</attribute>
+            </field>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="view_mail_mass_mailing_contact_search">
         <field name="name">Add partner search field and group by</field>
         <field name="model">mailing.contact</field>


### PR DESCRIPTION
Odoo 18 allows setting mass mailing contacts with split first/last names.

With this change, the module behavior is consistent when that setting is enabled. Those fields will be readonly if the contact name is synced from the partner, just like it was already happening with the `name` field.

https://www.loom.com/share/fb21a29158a9408091826ec1e8b81875

@moduon MT-13398
