### PR TITLE
[18.0][FIX] mass_mailing_partner: post_init_hooks

### DIFF
--- a/mass_mailing_partner/hooks.py
+++ b/mass_mailing_partner/hooks.py
@@ -17,9 +17,20 @@ def post_init_hook(env):
     contacts = contact_model.search([("email", "!=", False)])
     _logger.info("Trying to match %d contacts to partner by email", len(contacts))
     for contact in contacts:
-        partners = partner_model.search([("email", "=ilike", contact.email)], limit=1)
-        if partners:
+        partners = partner_model.search([("email", "=ilike", contact.email)])
+        if len(partners) == 1:
+            other_contact = contact_model.search(
+                [
+                    ("partner_id", "=", contact.partner_id.id),
+                    ("id", "!=", contact.id),
+                ]
+            )
+            if contact.list_ids & other_contact.mapped("list_ids"):
+                continue
+
             contact.write({"partner_id": partners.id})
+        else:
+            _logger.info("Skip matching: %d partners found!" % len(partners))
     # ACTION 2: Match existing statistics
     stat_model = env["mailing.trace"]
     stats = stat_model.search([("model", "!=", False), ("res_id", "!=", False)])

--- a/mass_mailing_partner/hooks.py
+++ b/mass_mailing_partner/hooks.py
@@ -26,8 +26,8 @@ def post_init_hook(env):
                 ]
             )
             if contact.list_ids & other_contact.mapped("list_ids"):
+                # This is because of duplicate records in the mailing contact
                 continue
-
             contact.write({"partner_id": partners.id})
         else:
             _logger.info("Skip matching: %d partners found!" % len(partners))


### PR DESCRIPTION
If you already have a duplicate records in the Mass Mailing List prior to the installation of this module, the post-init-hooks will fail because of the [_check_partner_id_list_ids](https://github.com/OCA/mass-mailing/blob/18.0/mass_mailing_partner/models/mailing_contact.py#L42) constrain.