### PR TITLE
Refactoring post init hook

### DIFF
--- a/mass_mailing_partner/hooks.py
+++ b/mass_mailing_partner/hooks.py
@@ -12,14 +12,36 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(env):
     # ACTION 1: Match existing contacts
-    contact_model = env["mailing.contact"]
-    partner_model = env["res.partner"]
-    contacts = contact_model.search([("email", "!=", False)])
-    _logger.info("Trying to match %d contacts to partner by email", len(contacts))
-    for contact in contacts:
-        partners = partner_model.search([("email", "=ilike", contact.email)], limit=1)
-        if partners:
-            contact.write({"partner_id": partners.id})
+       _logger.info("Trying to match contacts to partner by email")
+
+    matching_query = """
+        UPDATE mailing_contact mc
+        SET partner_id = rp.id
+        FROM res_partner rp
+        WHERE mc.email IS NOT NULL 
+          AND rp.email IS NOT NULL
+          AND LOWER(TRIM(mc.email)) = LOWER(TRIM(rp.email))
+    """
+    delete_older_tag_ids_query = """
+        DELETE FROM mailing_contact_res_partner_category_rel
+        WHERE mailing_contact_id IN (SELECT id FROM mailing_contact WHERE partner_id IS NOT NULL)
+    """
+    insert_tag_ids_query = """
+        INSERT INTO mailing_contact_res_partner_category_rel (mailing_contact_id, res_partner_category_id)
+        SELECT 
+            mc.id,
+            rprpcr.category_id
+        FROM mailing_contact mc
+        JOIN res_partner_res_partner_category_rel rprpcr ON mc.partner_id = rprpcr.partner_id
+        WHERE mc.partner_id IS NOT NULL
+    """
+
+    env.cr.execute(matching_query)
+    _logger.info("Mailing contacts updated: %d rows affected", env.cr.rowcount)
+
+    env.cr.execute(delete_older_tag_ids_query)
+    env.cr.execute(insert_tag_ids_query)
+
     # ACTION 2: Match existing statistics
     stat_model = env["mailing.trace"]
     stats = stat_model.search([("model", "!=", False), ("res_id", "!=", False)])


### PR DESCRIPTION
This pull request refactors the post_init_hook function in mass_mailing_partner/hooks.py to replace Python-based contact-partner matching with SQL queries for improved performance. The changes aim to efficiently match mailing contacts to partners by email and synchronize their category tags using direct database operations instead of ORM iterations.

Changes:

    Replaced Python loop for email-based contact-partner matching with a single SQL UPDATE statement
    Added SQL queries to delete and re-insert contact-category relationships based on matched partner categories

Context: 
We tried to initiate the app with previous mass mailing history, but mass_mailing_partner attempts to link historical mass mailing statistics (opens, clicks, bounces) to partners during installation. Without this step, only new contacts/statistics would be linked after installation, but this module tries to include historical data so reporting is complete from day one. The problem is that the linking function is inefficient: it processes records one by one. Since there are many records, the installation hits Odoo.sh time limits and fails.
