### PR TITLE
[19.0][IMP] mass_mailing_partner: Add partner_unique option to lists

### DIFF
--- a/mass_mailing_partner/models/mailing_list.py
+++ b/mass_mailing_partner/models/mailing_list.py
@@ -15,11 +15,16 @@ class MailingList(models.Model):
     partner_category = fields.Many2one(
         comodel_name="res.partner.category", string="Partner Tag"
     )
+    partner_unique = fields.Boolean(
+        string="Partner unique?",
+        help="If is checked, multiple contacts cannot be linked to the same partner",
+        default=True,
+    )
 
-    @api.constrains("contact_ids")
+    @api.constrains("partner_unique", "contact_ids")
     def _check_contact_ids_partner_id(self):
         contact_obj = self.env["mailing.contact"]
-        for mailing_list in self:
+        for mailing_list in self.filtered("partner_unique"):
             data = contact_obj._read_group(
                 [
                     ("id", "in", mailing_list.contact_ids.ids),

--- a/mass_mailing_partner/tests/test_mail_mass_mailing_list.py
+++ b/mass_mailing_partner/tests/test_mail_mass_mailing_list.py
@@ -23,6 +23,23 @@ class MailMassMailingListCase(base.BaseCase):
                 }
             )
 
+    def test_create_mass_mailing_list_not_partner_unique(self):
+        contact_test_1 = self.create_mailing_contact(
+            {"name": "Contact test 1", "partner_id": self.partner.id}
+        )
+        contact_test_2 = self.create_mailing_contact(
+            {"name": "Contact test 2", "partner_id": self.partner.id}
+        )
+        mailing_list = self.create_mailing_list(
+            {
+                "name": "List test Create Mailing List",
+                "partner_unique": False,
+                "contact_ids": [(6, 0, (contact_test_1 | contact_test_2).ids)],
+            }
+        )
+        with self.assertRaises(ValidationError):
+            mailing_list.partner_unique = True
+
     def test_create_mass_mailing_list_with_subscription(self):
         contact_test_1 = self.create_mailing_contact(
             {"name": "Contact test 1", "partner_id": self.partner.id}
@@ -37,3 +54,20 @@ class MailMassMailingListCase(base.BaseCase):
                     "contact_ids": [(4, contact_test_1.id), (4, contact_test_2.id)],
                 }
             )
+
+    def test_create_mass_mailing_list_with_subscription_not_partner_unique(self):
+        contact_test_1 = self.create_mailing_contact(
+            {"name": "Contact test 1", "partner_id": self.partner.id}
+        )
+        contact_test_2 = self.create_mailing_contact(
+            {"name": "Contact test 2", "partner_id": self.partner.id}
+        )
+        mailing_list = self.create_mailing_list(
+            {
+                "name": "List test Creat List With Subscription",
+                "partner_unique": False,
+                "contact_ids": [(4, contact_test_1.id), (4, contact_test_2.id)],
+            }
+        )
+        with self.assertRaises(ValidationError):
+            mailing_list.partner_unique = True

--- a/mass_mailing_partner/tests/test_mail_mass_mailing_list_contact_rel.py
+++ b/mass_mailing_partner/tests/test_mail_mass_mailing_list_contact_rel.py
@@ -20,3 +20,21 @@ class MailMassMailingListContactRelCase(base.BaseCase):
         )
         with self.assertRaises(ValidationError):
             list_3.contact_ids = [(4, contact_test_2.id)]
+
+    def test_create_mass_mailing_list_not_partner_unique(self):
+        contact_test_1 = self.create_mailing_contact(
+            {"name": "Contact test 1", "partner_id": self.partner.id}
+        )
+        contact_test_2 = self.create_mailing_contact(
+            {"name": "Contact test 2", "partner_id": self.partner.id}
+        )
+        list_3 = self.create_mailing_list(
+            {
+                "name": "List test 3",
+                "partner_unique": False,
+                "contact_ids": [(4, contact_test_1.id)],
+            }
+        )
+        list_3.contact_ids = [(4, contact_test_2.id)]
+        with self.assertRaises(ValidationError):
+            list_3.partner_unique = True

--- a/mass_mailing_partner/views/mailing_view.xml
+++ b/mass_mailing_partner/views/mailing_view.xml
@@ -15,6 +15,7 @@
                     <group>
                         <field name="partner_mandatory" />
                         <field name="partner_category" />
+                        <field name="partner_unique" />
                     </group>
                 </group>
             </xpath>


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/mass-mailing/pull/25

The partner_unique field is added to the lists; the existing validation error (multiple contacts with the same partner) will only be displayed if this field is checked.

Related to https://github.com/OCA/mass-mailing/commit/79dddb432c93721e0c945d30e5dbed0548283caa

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT61525