### PR TITLE
[18.0][FIX] mass_mailing_custom_unsubscribe: drop unsupported `test` tour option

### DIFF
--- a/mass_mailing_custom_unsubscribe/static/tests/contact.tour.esm.js
+++ b/mass_mailing_custom_unsubscribe/static/tests/contact.tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 registry
     .category("web_tour.tours")
     .add("mass_mailing_custom_unsubscribe_tour_contact", {
-        test: true,
         steps: () => [
             {
                 content: "Confirm unsubscribe",

--- a/mass_mailing_custom_unsubscribe/static/tests/partner.tour.esm.js
+++ b/mass_mailing_custom_unsubscribe/static/tests/partner.tour.esm.js
@@ -5,7 +5,6 @@ import {registry} from "@web/core/registry";
 registry
     .category("web_tour.tours")
     .add("mass_mailing_custom_unsubscribe_tour_partner", {
-        test: true,
         steps: () => [
             {
                 content: "Confirm unsubscribe",


### PR DESCRIPTION
The `test` option is no longer supported in tour registrations in Odoo 18 and causes the JavaScript module loader to fail with: Invalid object: unknown key 'test'
Remove the deprecated option so the tour loads correctly.

<img width="1553" height="417" alt="image" src="https://github.com/user-attachments/assets/3194d0a9-626d-4fb5-9259-ccdec4d18e1b" />

@Tecnativa 

@CarlosRoca13 @juancarlosonate-tecnativa please review